### PR TITLE
Added timestamp to logs when configured via custom formatter that use…

### DIFF
--- a/lib/LoggerBootstrap.js
+++ b/lib/LoggerBootstrap.js
@@ -73,8 +73,24 @@ function LoggerBoostrap(opts) {
 		json: true
 	};
 
-	const formatter = log => `${log.level}: ${log.message}`;
-	const formatterNoLevel = log => log.message;
+	const getFormatter = (useTimestamp) => {
+		if(useTimestamp) {
+			return log => `[${getTimestamp()}] ${log.level}: ${log.message}`;
+		}
+		else {
+			return log => `${log.level}: ${log.message}`;
+		}
+	};
+	const getFormatterNoLevel = (useTimestamp) => {
+		if(useTimestamp) {
+			return log => `[${getTimestamp()}] ${log.message}`;
+		}
+		else {
+			return log => log.message;
+		}
+	};
+	// winston just gets the current date as an ISO string winston/master:/lib/winston/common.js#302 at time of writing
+	const getTimestamp = () => new Date().toISOString();
 
 	const logDir = path.resolve(
 		process.cwd(), env('LOG_FILE_DIR', `/var/log/${opts.appName}`)
@@ -90,12 +106,11 @@ function LoggerBoostrap(opts) {
 				filename: path.join(logDir, 'app.log'),
 				maxsize: parseInt(env('LOG_FILE_MAX_SIZE', MB * 10)),
 				maxFiles: parseInt(env('LOG_FILE_MAX_FILES', 10)),
-				timestamp: envFlag('LOG_FILE_TIMESTAMP', true),
 				handleExceptions: true,
 				humanReadableUnhandledException: true,
 				tailable: true,
 				json: false,
-				formatter: formatter
+				formatter: getFormatter(envFlag('LOG_FILE_TIMESTAMP', true))
 			},
 			// Write error-level logs to a different file
 			errorFile: {
@@ -112,13 +127,13 @@ function LoggerBoostrap(opts) {
 				json: false,
 				formatter: log => (log.meta && log.meta.stack) ?
 					`Uncaught exception: ${log.meta.stack.join('\n')}` :
-					formatter(log)
+					getFormatter(envFlag('LOG_FILE_TIMESTAMP', true))(log)
 			},
 			console: {
 				silent: !envFlag('LOG_CONSOLE_ENABLED', true),
 				level: env('LOG_CONSOLE_LEVEL', 'info'),
 				timestamp: envFlag('LOG_CONSOLE_TIMESTAMP', true),
-				formatter: formatter
+				formatter: getFormatter(envFlag('LOG_CONSOLE_TIMESTAMP', true))
 			},
 			loggly: Object.assign({}, loggly, {
 				tags: loggly.tags.concat('app-log')
@@ -131,16 +146,14 @@ function LoggerBoostrap(opts) {
 				filename: path.join(logDir, 'access.log'),
 				maxsize: parseInt(env('REQUEST_LOG_FILE_MAX_SIZE', MB * 10)),
 				maxFiles: parseInt(env('REQUEST_LOG_FILE_MAX_FILES', 10)),
-				timestamp: envFlag('REQUEST_LOG_FILE_TIMESTAMP', true),
 				tailable: true,
 				json: false,
-				formatter: formatterNoLevel
+				formatter: getFormatterNoLevel(envFlag('REQUEST_LOG_FILE_TIMESTAMP', true))
 			},
 			console: {
 				silent: !envFlag('REQUEST_LOG_CONSOLE_ENABLED', true),
 				level: env('REQUEST_LOG_CONSOLE_LEVEL', 'info'),
-				timestamp: envFlag('REQUEST_LOG_CONSOLE_TIMESTAMP', true),
-				formatter: formatterNoLevel
+				formatter: getFormatterNoLevel(envFlag('REQUEST_LOG_CONSOLE_TIMESTAMP', true))
 			},
 			loggly: Object.assign({}, loggly, {
 				tags: loggly.tags.concat('access-log')

--- a/test/spec/LoggerBootstrapTest.js
+++ b/test/spec/LoggerBootstrapTest.js
@@ -36,14 +36,12 @@ describe('LoggerBootstrap', () => {
 				filename: `${process.cwd()}/log/app.log`,
 				maxsize: 1024 * 1024 * 10,		// 10 MB
 				maxFiles: 10,
-				timestamp: true,
 				tailable: true
 			}, 'app log (file)');
 
 			assert.partial(config.appLog.console, {
 				silent: false,
 				level: 'info',
-				timestamp: true
 			}, 'app log (console)');
 
 			assert.partial(config.requestLog.file, {
@@ -52,14 +50,12 @@ describe('LoggerBootstrap', () => {
 				filename: `${process.cwd()}/log/access.log`,
 				maxsize: 1024 * 1024 * 10,		// 10 MB
 				maxFiles: 10,
-				timestamp: true,
 				tailable: true
 			}, 'access log (file)');
 
 			assert.partial(config.appLog.console, {
 				silent: false,
 				level: 'info',
-				timestamp: true
 			}, 'access log (console)');
 		});
 
@@ -104,14 +100,12 @@ describe('LoggerBootstrap', () => {
 				filename: `${process.cwd()}/log/app.log`,
 				maxsize: 507,
 				maxFiles: 11,
-				timestamp: true,
 				tailable: true
 			}, 'app log (file)');
 
 			assert.partial(config.appLog.console, {
 				silent: false,
 				level: 'verbose',
-				timestamp: false
 			}, 'app log (console)');
 
 			assert.partial(config.requestLog.file, {
@@ -120,14 +114,12 @@ describe('LoggerBootstrap', () => {
 				filename: `${process.cwd()}/log/access.log`,
 				maxsize: 202,
 				maxFiles: 6,
-				timestamp: false,
 				tailable: true
 			}, 'access log (file)');
 
 			assert.partial(config.requestLog.console, {
 				silent: true,
 				level: 'silly',
-				timestamp: true
 			}, 'access log (console)');
 		});
 


### PR DESCRIPTION
…s this config.

Fixes #1 

The formatter function needs to be configured differently between different transports. The "formatter" functions got turned into getters that are configured with the timestamp config. The 0 test coverage on this is verifying that it works.

Also removed timestamp config checks from the tests because that isn't getting set anymore.
