### PR TITLE
Fixed a bug where the log file was created even though it was configu…

### DIFF
--- a/lib/LoggerBootstrap.js
+++ b/lib/LoggerBootstrap.js
@@ -74,8 +74,6 @@ function LoggerBoostrap(opts) {
 	const logDir = path.resolve(
 		process.cwd(), env('LOG_FILE_DIR', `/var/log/${opts.appName}`)
 	);
-	fs.ensureDirSync(logDir);
-
 
 	const logglyEnabled = envFlag('LOGGLY_ENABLED', false);
 	const loggly = {
@@ -175,6 +173,10 @@ function LoggerBoostrap(opts) {
 			})
 		}
 	};
+
+	if(!config.appLog.silent || !config.errorFile.silent || !config.requestLog.file.silent) {
+		fs.ensureDirSync(logDir);
+	}
 
 	const logLoggerError = loggerName => err => console.error(`${loggerName} Logger failed: ${err.stack}`);
 

--- a/lib/LoggerBootstrap.js
+++ b/lib/LoggerBootstrap.js
@@ -174,7 +174,7 @@ function LoggerBoostrap(opts) {
 		}
 	};
 
-	if(!config.appLog.silent || !config.errorFile.silent || !config.requestLog.file.silent) {
+	if(!config.appLog.file.silent || !config.appLog.errorFile.silent || !config.requestLog.file.silent) {
 		fs.ensureDirSync(logDir);
 	}
 


### PR DESCRIPTION
…red to be disabled/silent. This can throw access errors when trying to create a directory that's not owned by the user, even though file logs were never intended.

Totally tested, yup. Don't even have to look.
